### PR TITLE
Added some version specifications for packages in mvn.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -450,6 +450,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+                                <version>2.19.1</version>
 
 				<configuration>
 					<forkCount>1</forkCount>
@@ -462,6 +463,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+                                <version>1.5.0</version>
 				<configuration>
 					<mainClass>nz.co.fortytwo.signalk.server.ServerMain</mainClass>
 					<includePluginDependencies>false</includePluginDependencies>
@@ -470,6 +472,7 @@
 			<plugin>
 				<groupId>org.mortbay.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
+                                <version>8.1.16.v20140903</version>
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Using NetBeans for development, missing package version specs are reported:

---

cd /home/rberliner/Dropbox/freeboard/signalk-server-java; JAVA_HOME=/home/rberliner/jdk1.8.0_71 /home/rberliner/netbeans-8.1/java/maven/bin/mvn --errors --errors clean install
[INFO] Error stacktraces are turned on.
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for nz.co.fortytwo.signalk.server:signalk-server-java:jar:0.0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing. @ line 462, column 12
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 450, column 12
[WARNING] 'build.plugins.plugin.version' for org.mortbay.jetty:jetty-maven-plugin is missing. @ line 470, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 

---

This has been fixed by specifying the latest package versions on the pom.
